### PR TITLE
Fix 'QMessageBox' has no attribute 'Error'

### DIFF
--- a/util.py
+++ b/util.py
@@ -30,7 +30,7 @@ def show_dialog_inner(title, message, buttons, icon=QMessageBox.Information, mes
   return msg.exec_()
 
 def show_error(title, message, message_extra="", parent=None):
-  return show_dialog_inner(title, message, QMessageBox.Ok | QMessageBox.Cancel, QMessageBox.Error, message_extra=message_extra, parent=parent)
+  return show_dialog_inner(title, message, QMessageBox.Ok | QMessageBox.Cancel, QMessageBox.Critical, message_extra=message_extra, parent=parent)
 
 def show_dialog(title, message, message_extra="", parent=None):
   return show_dialog_inner(title, message, QMessageBox.Ok | QMessageBox.Cancel, QMessageBox.Information, message_extra=message_extra, parent=parent)


### PR DESCRIPTION
using the pip installed requirements, I got this error:

```
Traceback (most recent call last):
  File "main.py", line 48, in <module>
    show_error("Sync Error", 
  File "/opt/raven-trader-pro/util.py", line 33, in show_error
    return show_dialog_inner(title, message, QMessageBox.Ok | QMessageBox.Cancel, QMessageBox.Error, message_extra=message_extra, parent=parent)
AttributeError: type object 'QMessageBox' has no attribute 'Error'
```

Changing it to "Critical" seemed to make it work as intended!